### PR TITLE
#10 Add NuGet package publishing workflow and metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: Publish NuGet Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version (e.g., 1.0.0)'
+        required: true
+        type: string
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  PROJECT_PATH: 'src/LightTrace/LightTrace.csproj'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+      
+    - name: Run tests
+      run: dotnet test --configuration Release --no-build --verbosity normal
+      
+    - name: Set package version
+      id: version
+      run: |
+        if [ "${{ github.event_name }}" == "release" ]; then
+          VERSION="${{ github.event.release.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION=${VERSION#v}
+        else
+          VERSION="${{ github.event.inputs.version }}"
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+        echo "Package version: $VERSION"
+        
+    - name: Pack NuGet package
+      run: |
+        dotnet pack ${{ env.PROJECT_PATH }} \
+          --configuration Release \
+          --no-build \
+          --output ./artifacts \
+          -p:PackageVersion=${{ steps.version.outputs.VERSION }} \
+          -p:AssemblyVersion=${{ steps.version.outputs.VERSION }} \
+          -p:FileVersion=${{ steps.version.outputs.VERSION }}
+          
+    - name: Upload package artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: ./artifacts/*.nupkg
+        
+    - name: Publish to NuGet.org
+      run: |
+        dotnet nuget push ./artifacts/*.nupkg \
+          --api-key ${{ secrets.NUGET_API_KEY }} \
+          --source https://api.nuget.org/v3/index.json \
+          --skip-duplicate
+          
+    - name: Create release notes
+      if: github.event_name == 'release'
+      run: |
+        echo "## Package Published" >> $GITHUB_STEP_SUMMARY
+        echo "? LightTrace v${{ steps.version.outputs.VERSION }} has been published to NuGet.org" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "?? [View on NuGet.org](https://www.nuget.org/packages/LightTrace/${{ steps.version.outputs.VERSION }})" >> $GITHUB_STEP_SUMMARY

--- a/LightTrace.sln
+++ b/LightTrace.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{089100B1-113F-4E66-888A-E83F3999EAFD}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
+		.github\workflows\publish.yml = .github\workflows\publish.yml
 		src\SetParameters.ps1 = src\SetParameters.ps1
 	EndProjectSection
 EndProject

--- a/src/LightTrace/LightTrace.csproj
+++ b/src/LightTrace/LightTrace.csproj
@@ -3,6 +3,29 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    
+    <!-- Package Information -->
+    <PackageId>LightTrace</PackageId>
+    <Title>LightTrace</Title>
+    <Description>A lightweight tracing library for .NET applications</Description>
+    <Authors>vantonenko</Authors>
+    <Company>vantonenko</Company>
+    <Copyright>Copyright © vantonenko</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/vantonenko/LightTrace</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/vantonenko/LightTrace</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>tracing;logging;performance;diagnostics;dotnet</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    
+    <!-- Generate package on build -->
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" Condition="Exists('..\..\README.md')" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Introduced `publish.yml` GitHub Actions workflow for automating NuGet package publishing on release events and manual triggers.
- Updated `LightTrace.sln` to include the new workflow in Solution Items.
- Enhanced `LightTrace.csproj` with package metadata such as `PackageId`, `Title`, `Description`, and more, enabling proper NuGet package generation and symbol inclusion.